### PR TITLE
So IE8 can work when no headers are returned

### DIFF
--- a/libxdr.js
+++ b/libxdr.js
@@ -88,7 +88,11 @@ if (!this.XDR) {
         instance.responseXML = xmlDocument;
         
         instance.responseText = response.data;
-        
+       
+        if (!response.headers) {
+          response.headers = {};
+        }
+
         instance.contentType = response.headers["content-type"];
            
         var headers = [];


### PR DESCRIPTION
IE8 tends to throw errors when you use object.property[name] and object1 does not have that property defined.
